### PR TITLE
users: fix sudo sed

### DIFF
--- a/src/functions/users.rs
+++ b/src/functions/users.rs
@@ -57,8 +57,8 @@ pub fn new_user(username: &str, hasroot: bool, password: &str, do_hash_pass: boo
         files_eval(
             files::sed_file(
                 "/mnt/etc/sudoers",
-                "# %wheel ALL=(ALL) ALL",
-                "%wheel ALL=(ALL) ALL",
+                "# %wheel ALL=(ALL:ALL) ALL",
+                "%wheel ALL=(ALL:ALL) ALL",
             ),
             "Add wheel group to sudoers",
         );


### PR DESCRIPTION
you need to put `:ALL` after `ALL` in the suoders thing, since that bit of code was looking for a string that,,,,, doesn't exist, so the replace didnt work.

original file for reference
![image](https://user-images.githubusercontent.com/80879058/189509338-fea95165-5f99-4b73-bb5b-74afb6be3e86.png)
