### PR TITLE
Populates AccountsService by default

### DIFF
--- a/src/functions/users.rs
+++ b/src/functions/users.rs
@@ -66,6 +66,21 @@ pub fn new_user(username: &str, hasroot: bool, password: &str, do_hash_pass: boo
             files::append_file("/mnt/etc/sudoers", "\nDefaults pwfeedback\n"),
             "Add pwfeedback to sudoers",
         );
+        files_eval(
+            Ok(files::create_file(&format!(
+                "/mnt/var/lib/AccountsService/users/{}",
+                username
+            ))),
+            format!("Create AccountsService user file for {}", username).as_str(),
+        );
+        files_eval(
+            files::append_file(
+                &format!("/mnt/var/lib/AccountsService/users/{}", username),
+                r#"[User]
+                Session=onyx"#,
+            ),
+            format!("Populate AccountsService user file for {}", username).as_str(),
+        )
     }
 }
 

--- a/src/functions/users.rs
+++ b/src/functions/users.rs
@@ -66,13 +66,7 @@ pub fn new_user(username: &str, hasroot: bool, password: &str, do_hash_pass: boo
             files::append_file("/mnt/etc/sudoers", "\nDefaults pwfeedback\n"),
             "Add pwfeedback to sudoers",
         );
-        files_eval(
-            Ok(files::create_file(&format!(
-                "/mnt/var/lib/AccountsService/users/{}",
-                username
-            ))),
-            format!("Create AccountsService user file for {}", username).as_str(),
-        );
+        files::create_file(&format!("/mnt/var/lib/AccountsService/users/{}", username));
         files_eval(
             files::append_file(
                 &format!("/mnt/var/lib/AccountsService/users/{}", username),


### PR DESCRIPTION
This populates the user AccountsService file as Onyx by default.

This is actually fine as if the Onyx session file doesn't exist it simply will default to GNOME / whatever the next default would have been.