### PR TITLE
Update Version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "jade"
 description = "The new installer for crystal linux, contains backend and TUI"
 authors = ["Amy <axtlos@tar.black>"]
-version = "0.1.0"
-edition = "2021"
+version = "1.2.0"
+edition = "2022"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "jade"
 description = "The new installer for crystal linux, contains backend and TUI"
 authors = ["Amy <axtlos@tar.black>"]
 version = "1.2.0"
-edition = "2022"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Hi,

The `version` var in the `Cargo.toml` file still points to the `0.1.0` version leading to a wrong printed version when using the -V/--version argument:

```
 rcandau@arch-build  /tmp/jade  cat PKGBUILD
# Maintainer: echo -n 'bWF0dEBnZXRjcnlzdC5hbA==' | base64 -d
# Contributor: echo -n 'cmNhbmRhdUBnZXRjcnlzdC5hbA==' | base64 -d

pkgname=jade
**pkgver=1.2.0**
[...]
```
```
 rcandau@arch-build  /tmp/jade  jade -V
jade 0.1.0
```

This PR aims to correct that by changing the `version` var's value from `0.1.0` to `1.2.0`.

```
 rcandau@arch-build  /tmp/jade  jade -V
jade 1.2.0
```