### PR TITLE
Addition of crystal-core and crystal-branding

### DIFF
--- a/src/functions/base.rs
+++ b/src/functions/base.rs
@@ -34,9 +34,9 @@ pub fn install_base_packages(kernel: String) {
         "sudo",
         "curl",
         "archlinux-keyring",
-	// Base Crystal
-	"crystal-core",
-	"crystal-branding",
+        // Base Crystal
+        "crystal-core",
+        "crystal-branding",
         // Extra goodies
         "neofetch",
         "btrfs-progs",

--- a/src/functions/base.rs
+++ b/src/functions/base.rs
@@ -34,6 +34,9 @@ pub fn install_base_packages(kernel: String) {
         "sudo",
         "curl",
         "archlinux-keyring",
+	// Base Crystal
+	"crystal-core",
+	"crystal-branding"
         // Extra goodies
         "neofetch",
         "btrfs-progs",
@@ -76,6 +79,7 @@ pub fn install_bootloader_efi(efidir: PathBuf) {
         "grub-btrfs",
         "crystal-grub-theme",
         "os-prober",
+        "crystal-branding",
     ]);
     let efidir = std::path::Path::new("/mnt").join(efidir);
     let efi_str = efidir.to_str().unwrap();
@@ -127,6 +131,7 @@ pub fn install_bootloader_legacy(device: PathBuf) {
         "grub-btrfs",
         "crystal-grub-theme",
         "os-prober",
+        "crystal-branding",
     ]);
     if !device.exists() {
         crash(format!("The device {device:?} does not exist"), 1);

--- a/src/functions/base.rs
+++ b/src/functions/base.rs
@@ -36,7 +36,7 @@ pub fn install_base_packages(kernel: String) {
         "archlinux-keyring",
 	// Base Crystal
 	"crystal-core",
-	"crystal-branding"
+	"crystal-branding",
         // Extra goodies
         "neofetch",
         "btrfs-progs",


### PR DESCRIPTION
Hi,

Two new packages has been recently added to the [Crystal's packages GitHub organisation](https://github.com/crystal-linux-packages), they will have to be installed during any Crystal installation.

- [crystal-core](https://github.com/crystal-linux-packages/crystal-core), which is a meta package that aims to install `ame`, `crystal-keyring` and `crystal-mirrorlist`. This was previously handled by our custom `base` package which has recently been dropped in favor of this `crystal-core` package.
- [crystal-branding](https://github.com/crystal-linux-packages/crystal-branding), which aims to install the Crystal global branding (logo, `/etc/issue`, `/etc/os-release`) but also to set the "GRUB_DISTRIBUTOR" variable's value in `/etc/default/grub` if `grub` is installed (but without actually depending on `grub`). 
Therefore, it will have to be installed twice on systems that use `grub`. Once as a `base` package and once **after** `grub` has been installed in order to update the "GRUB_DISTRIBUTOR" variable's value in `/etc/default/grub`.

Hopefully, this PR is correct :sweat_smile:
Don't hesitate to ask for changes if needed :smile: 